### PR TITLE
Update NovaGenerator.php

### DIFF
--- a/src/NovaGenerator.php
+++ b/src/NovaGenerator.php
@@ -84,7 +84,7 @@ class NovaGenerator implements Generator
         return $stub;
     }
 
-    private function getNovaNamespace(Model $model): string
+    protected function getNovaNamespace(Model $model): string
     {
         $namespace = Str::of($model->fullyQualifiedNamespace())
             ->after(config('blueprint.namespace'))


### PR DESCRIPTION
I Made the getNovaNamespace function protected so it can be easily extended.
The main reason for this is because I don't want to use the `DateTime` fields in my nova resources.

I can extend your generator and only change the pipeline section a bit but I need access to the `getNovaNamespace` function which I now need to copy over.