### PR TITLE
Use id or primary keys as identifiers to allow for string primary key

### DIFF
--- a/src/Tasks/InteractWithRelationships.php
+++ b/src/Tasks/InteractWithRelationships.php
@@ -15,7 +15,7 @@ trait InteractWithRelationships
             })
             // map id columns to match related relationships
             ->map(function (Column $column) {
-                return empty($column->attributes())
+                return empty($column->attributes()) || in_array('primary', $column->modifiers())
                     ? $column->name()
                     : implode(':', $column->attributes()).":{$column->name()}";
             });

--- a/src/Tasks/InteractWithRelationships.php
+++ b/src/Tasks/InteractWithRelationships.php
@@ -11,7 +11,7 @@ trait InteractWithRelationships
     {
         return collect($columns)
             ->filter(function (Column $column) {
-                return $column->dataType() === 'id';
+                return $column->dataType() === 'id' || in_array('primary', $column->modifiers());
             })
             // map id columns to match related relationships
             ->map(function (Column $column) {

--- a/tests/NovaGeneratorTest.php
+++ b/tests/NovaGeneratorTest.php
@@ -155,6 +155,7 @@ class NovaGeneratorTest extends TestCase
             ['definitions/relationships.bp', 'app/Nova/Comment.php', 'nova/relationships.php'],
             ['definitions/unconventional.bp', 'app/Nova/Team.php', 'nova/unconventional.php'],
             ['definitions/nullable-relationships.bp', 'app/Nova/Subscription.php', 'nova/nullable-relationships.php'],
+            ['definitions/string-primary-key.bp', 'app/Nova/Post.php', 'nova/string-primary-key.php'],
             /*
              * @todo work on this
              */

--- a/tests/fixtures/definitions/string-primary-key.bp
+++ b/tests/fixtures/definitions/string-primary-key.bp
@@ -1,6 +1,6 @@
 models:
   Post:
-    id: string primary
+    id: string:10 primary
     title: string:400
     content: longtext
     published_at: nullable timestamp

--- a/tests/fixtures/definitions/string-primary-key.bp
+++ b/tests/fixtures/definitions/string-primary-key.bp
@@ -1,0 +1,6 @@
+models:
+  Post:
+    id: string primary
+    title: string:400
+    content: longtext
+    published_at: nullable timestamp

--- a/tests/fixtures/nova/string-primary-key.php
+++ b/tests/fixtures/nova/string-primary-key.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Nova;
+
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\Textarea;
+
+class Post extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model = \App\Post::class;
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'id';
+
+    /**
+     * The columns that should be searched.
+     *
+     * @var array
+     */
+    public static $search = [
+        'id',
+    ];
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            ID::make()->sortable(),
+
+            Text::make('Title')
+                ->rules('required', 'string', 'max:400'),
+
+            Textarea::make('Content')
+                ->rules('required', 'string'),
+
+            DateTime::make('Published at'),
+
+            DateTime::make('Created at'),
+            DateTime::make('Updated at'),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function cards(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function lenses(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function actions(Request $request)
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Use id or primary keys as identifiers to allow for string primary key to be used