### PR TITLE
Add types function defined in the Blueprint Generator contract.

### DIFF
--- a/src/NovaGenerator.php
+++ b/src/NovaGenerator.php
@@ -117,4 +117,9 @@ class NovaGenerator implements Generator
 
         return array_merge($tasks, [new RemapImports]);
     }
+
+    public function types(): array
+    {
+        return ['nova'];
+    }
 }


### PR DESCRIPTION
After installing newest version of this repo and Blueprint, I got following error when building a blueprint.

```bash
PHP Fatal error:  Class Naoray\BlueprintNovaAddon\NovaGenerator contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Blueprint\Contracts\Generator::types) in /vendor/naoray/blueprint-nova-addon/src/NovaGenerator.php on line 14
```

It was just the `types()` function that was missing. I added this now and defined the `nova` type in it. It was added in [this commit](https://github.com/laravel-shift/blueprint/commit/deafe7131f50664e122440c3384a499029ab9a29). So now it's also possible to run `php artisan blueprint:build blueprint/pages.yml --only=nova`. This will generate only the Nova resources.