### PR TITLE
If datatype is an uuid, do not use as regular field

### DIFF
--- a/src/Tasks/AddRegularFields.php
+++ b/src/Tasks/AddRegularFields.php
@@ -45,6 +45,7 @@ class AddRegularFields implements Task
         return collect($columns)
             ->filter(function (Column $column) {
                 return $column->dataType() !== 'id'
+                    && $column->dataType() !== 'uuid'
                     && ! collect(['id', 'deleted_at', 'created_at', 'updated_at'])->contains($column->name());
             });
     }

--- a/tests/fixtures/definitions/model-relationships.bp
+++ b/tests/fixtures/definitions/model-relationships.bp
@@ -1,6 +1,7 @@
 models:
   Subscription:
     user_id: id
+    team_id: uuid
     relationships:
       belongsToMany: Team
       hasMany: Order

--- a/tests/fixtures/nova/model-relationships.php
+++ b/tests/fixtures/nova/model-relationships.php
@@ -47,6 +47,7 @@ class Subscription extends Resource
             ID::make()->sortable(),
 
             BelongsTo::make('User'),
+            BelongsTo::make('Team'),
 
             BelongsToMany::make('Teams'),
 


### PR DESCRIPTION
If you have an uuid now, it was also added as:

```php
return [
    ID::make()->sortable(),

    Text::make('Team id')
        ->rules('required'),

    BelongsTo::make('Team'),

    DateTime::make('Created at'),
    DateTime::make('Updated at'),
];
```

The `Text` field was not necessary, with this update it will be removed and only the `BelongsTo` will be added.
