### PR TITLE
Added support for custom namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ public function fields(Request $request)
 You may publish the configuration with the following command:
 
 ```bash
-php artisan vendor:publish --tag=blueprint-nova-config
+php artisan vendor:publish --tag=nova_blueprint
 ```
 
 ### Timestamp fields

--- a/config/nova_blueprint.php
+++ b/config/nova_blueprint.php
@@ -15,4 +15,38 @@ return [
     */
 
     'timestamps' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Nova Namespace
+    |--------------------------------------------------------------------------
+    |
+    | Nova Blueprint recommends sticking to the standard `App\Nova` namespace
+    | used in the Nova docs all your Nova resources.  However, if you want to
+    | create these resources in a different namespace, you can change the
+    | default namespace below.
+    |
+    | This namespace will be prefixed with the namespace defined in Laravel
+    | Blueprint.
+    |
+    */
+    'namespace' => 'Nova',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Nova Component Namespaces
+    |--------------------------------------------------------------------------
+    |
+    | Nova Blueprint uses the namespaces as defined in the Laravel docs for
+    | your Nova Components. These too, can be customized to your liking.
+    |
+    | The Nova components will be prefixed with the Nova namespace and the
+    | Blueprint namespace, so a default action namespace would be
+    | `App\Nova\Actions`.
+    |
+    | Use null if you want to put the component in the root of your Nova
+    | namespace.
+    |
+    */
+    'resource_namespace' => null,
 ];

--- a/src/NovaGenerator.php
+++ b/src/NovaGenerator.php
@@ -81,14 +81,17 @@ class NovaGenerator implements Generator
 
     protected function getNovaNamespace(Model $model): string
     {
-        $namespace = Str::after($model->fullyQualifiedNamespace(), config('blueprint.namespace'));
-        $namespace = config('blueprint.namespace').'\Nova'.$namespace;
+        $afterSelector = config('blueprint.models_namespace') ?: config('blueprint.namespace');
+        $namespace = Str::after($model->fullyQualifiedNamespace(), $afterSelector);
 
-        if (config('blueprint.models_namespace')) {
-            $namespace = str_replace('\\'.config('blueprint.models_namespace'), '', $namespace);
-        }
+        $namespace = implode('\\', array_filter([
+            config('blueprint.namespace'),
+            config('nova_blueprint.namespace', 'Nova'),
+            config('nova_blueprint.resource_namespace', null),
+            $namespace,
+        ]));
 
-        return $namespace;
+        return ltrim($namespace, '\\');
     }
 
     public function registerTask(Task $task): void

--- a/tests/NovaGeneratorTest.php
+++ b/tests/NovaGeneratorTest.php
@@ -148,6 +148,32 @@ class NovaGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Nova/Comment.php']], $this->subject->output($tree));
     }
 
+    /**
+     * @test
+     */
+    public function output_respects_namespace_configurations()
+    {
+        $this->app['config']->set('nova_blueprint.namespace', 'Admin');
+        $this->app['config']->set('nova_blueprint.resource_namespace', 'Resources');
+
+        $this->files->expects('get')
+            ->with($this->stubPath().DIRECTORY_SEPARATOR.'class.stub')
+            ->andReturn(file_get_contents('stubs/class.stub'));
+
+        $this->files->expects('exists')
+            ->with('app/Admin/Resources')
+            ->andReturnFalse();
+        $this->files->expects('makeDirectory')
+            ->with('app/Admin/Resources', 0755, true);
+        $this->files->expects('put')
+            ->with('app/Admin/Resources/Video.php', $this->fixture('nova/custom-namespace.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/custom-namespace.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['app/Admin/Resources/Video.php']], $this->subject->output($tree));
+    }
+
     public function novaTreeDataProvider()
     {
         return [

--- a/tests/fixtures/definitions/custom-namespace.bp
+++ b/tests/fixtures/definitions/custom-namespace.bp
@@ -1,0 +1,3 @@
+models:
+  Video:
+    title: string

--- a/tests/fixtures/nova/custom-namespace.php
+++ b/tests/fixtures/nova/custom-namespace.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Admin\Resources;
+
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\DateTime;
+
+class Video extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model = \App\Video::class;
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'id';
+
+    /**
+     * The columns that should be searched.
+     *
+     * @var array
+     */
+    public static $search = [
+        'id',
+    ];
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function fields(Request $request)
+    {
+        return [
+            ID::make()->sortable(),
+
+            Text::make('Title')
+                ->rules('required', 'string'),
+
+            DateTime::make('Created at'),
+            DateTime::make('Updated at'),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function cards(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function filters(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function lenses(Request $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function actions(Request $request)
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
I looked at how Blueprint did it, and split the logic in two parts, to 
allow for future extensibility with Lenses or Actions.

This adds support for a base "Nova Namespace" and a, default-empty, "Resource namespace".

Also added some tests to check if it works as expected.

Closes #30 and fixes #29