### PR TITLE
Add support for blueprint v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "illuminate/pipeline": "^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
-        "laravel-shift/blueprint": "^1.18"
+        "laravel-shift/blueprint": "^1.18 || ^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",


### PR DESCRIPTION
This  pull request makes sure that blueprint is compatible with Blueprint v2.

Tests are still running without errors.